### PR TITLE
Rails 5 + MySQL, SQLite support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ before_script:
   - psql -c 'create database activeuuid_test;' -U postgres
 
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.5
   - 2.2.0
@@ -53,8 +52,6 @@ matrix:
     - rvm: jruby
       gemfile: gemfiles/Gemfile.rails-5-0
       env: DB=postgresql
-    - rvm: 1.9.3
-      gemfile: gemfiles/Gemfile.rails-5-0
     - rvm: jruby
       gemfile: gemfiles/Gemfile.rails-5-0
       env: DB=postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.0.0
   - 2.1.5
   - 2.2.0
+  - 2.3.1
   - rbx-2
   - jruby
 
@@ -17,6 +18,7 @@ gemfile:
   - gemfiles/Gemfile.rails-4-0
   - gemfiles/Gemfile.rails-4-1
   - gemfiles/Gemfile.rails-4-2
+  - gemfiles/Gemfile.rails-5-0
   - gemfiles/Gemfile.rails-head
 
 env:
@@ -30,7 +32,11 @@ matrix:
   exclude:
     - rvm: 2.2.0
       gemfile: gemfiles/Gemfile.rails-3-1
+    - rvm: 2.3.1
+      gemfile: gemfiles/Gemfile.rails-3-1
     - rvm: 2.2.0
+      gemfile: gemfiles/Gemfile.rails-3-2
+    - rvm: 2.3.1
       gemfile: gemfiles/Gemfile.rails-3-2
     - rvm: jruby
       gemfile: gemfiles/Gemfile.rails-3-1
@@ -44,4 +50,11 @@ matrix:
     - rvm: jruby
       gemfile: gemfiles/Gemfile.rails-4-1
       env: DB=postgresql
-
+    - rvm: jruby
+      gemfile: gemfiles/Gemfile.rails-5-0
+      env: DB=postgresql
+    - rvm: 1.9.3
+      gemfile: gemfiles/Gemfile.rails-5-0
+    - rvm: jruby
+      gemfile: gemfiles/Gemfile.rails-5-0
+      env: DB=postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,3 +60,10 @@ matrix:
     - rvm: jruby
       gemfile: gemfiles/Gemfile.rails-5-0
       env: DB=postgresql
+    - rvm: 2.0.0
+      gemfile: gemfiles/Gemfile.rails-head
+    - rvm: 2.1.10
+      gemfile: gemfiles/Gemfile.rails-head
+    - rvm: jruby
+      gemfile: gemfiles/Gemfile.rails-head
+      env: DB=postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,3 @@ matrix:
     - rvm: jruby
       gemfile: gemfiles/Gemfile.rails-5-0
       env: DB=postgresql
-    - rvm: jruby
-      gemfile: gemfiles/Gemfile.rails-5-0
-      env: DB=postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ before_script:
 
 rvm:
   - 2.0.0
-  - 2.1.5
-  - 2.2.0
+  - 2.1.10
+  - 2.2.5
   - 2.3.1
   - rbx-2
   - jruby
@@ -29,17 +29,21 @@ matrix:
   allow_failures:
     - gemfile: gemfiles/Gemfile.rails-head
   exclude:
-    - rvm: 2.2.0
+    - rvm: 2.0.0
+      gemfile: Gemfile
+    - rvm: 2.1.10
+      gemfile: Gemfile
+    - rvm: 2.2.5
       gemfile: gemfiles/Gemfile.rails-3-1
     - rvm: 2.3.1
       gemfile: gemfiles/Gemfile.rails-3-1
-    - rvm: 2.2.0
-      gemfile: gemfiles/Gemfile.rails-3-2
-    - rvm: 2.3.1
-      gemfile: gemfiles/Gemfile.rails-3-2
     - rvm: jruby
       gemfile: gemfiles/Gemfile.rails-3-1
       env: DB=postgresql
+    - rvm: 2.2.5
+      gemfile: gemfiles/Gemfile.rails-3-2
+    - rvm: 2.3.1
+      gemfile: gemfiles/Gemfile.rails-3-2
     - rvm: jruby
       gemfile: gemfiles/Gemfile.rails-3-2
       env: DB=postgresql
@@ -49,6 +53,10 @@ matrix:
     - rvm: jruby
       gemfile: gemfiles/Gemfile.rails-4-1
       env: DB=postgresql
+    - rvm: 2.0.0
+      gemfile: gemfiles/Gemfile.rails-5-0
+    - rvm: 2.1.10
+      gemfile: gemfiles/Gemfile.rails-5-0
     - rvm: jruby
       gemfile: gemfiles/Gemfile.rails-5-0
       env: DB=postgresql

--- a/gemfiles/Gemfile.rails-3-1
+++ b/gemfiles/Gemfile.rails-3-1
@@ -2,4 +2,5 @@ source "http://rubygems.org"
 
 gemspec path: '../'
 
+gem 'mysql2', '~> 0.3.21'
 gem 'activerecord', '~> 3.1.0'

--- a/gemfiles/Gemfile.rails-3-2
+++ b/gemfiles/Gemfile.rails-3-2
@@ -2,4 +2,5 @@ source "http://rubygems.org"
 
 gemspec path: '../'
 
+gem 'mysql2', '~> 0.3.21'
 gem 'activerecord', '~> 3.2.0'

--- a/gemfiles/Gemfile.rails-4-0
+++ b/gemfiles/Gemfile.rails-4-0
@@ -2,4 +2,5 @@ source "http://rubygems.org"
 
 gemspec path: '../'
 
+gem 'mysql2', '~> 0.3.21'
 gem 'activerecord', '~> 4.0.0'

--- a/gemfiles/Gemfile.rails-4-1
+++ b/gemfiles/Gemfile.rails-4-1
@@ -2,4 +2,5 @@ source "http://rubygems.org"
 
 gemspec path: '../'
 
+gem 'mysql2', '~> 0.3.21'
 gem 'activerecord', '~> 4.1.0'

--- a/gemfiles/Gemfile.rails-5-0
+++ b/gemfiles/Gemfile.rails-5-0
@@ -1,0 +1,5 @@
+source "http://rubygems.org"
+
+gemspec path: '../'
+
+gem 'activerecord', '~> 5.0.0'

--- a/lib/activeuuid/patches.rb
+++ b/lib/activeuuid/patches.rb
@@ -30,7 +30,6 @@ if (ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR == 2) ||
             def type_cast_from_user(value)
               UUIDTools::UUID.serialize(value) if value
             end
-            alias_method :type_cast_from_database, :type_cast_from_user
           end
         end
       end

--- a/lib/activeuuid/patches.rb
+++ b/lib/activeuuid/patches.rb
@@ -169,6 +169,14 @@ module ActiveUUID
       end
     end
 
+    module PostgresqlTypeOverride
+      def deserialize(value)
+        UUIDTools::UUID.serialize(value) if value
+      end
+
+      alias_method :cast, :deserialize
+    end
+
     module TypeMapOverride
       def initialize_type_map(m)
         super
@@ -197,6 +205,7 @@ module ActiveUUID
           end
 
           ActiveRecord::ConnectionAdapters::SQLite3Adapter.prepend TypeMapOverride if defined? ActiveRecord::ConnectionAdapters::SQLite3Adapter
+          ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Uuid.prepend PostgresqlTypeOverride if defined? ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
         elsif ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR == 2
           ActiveRecord::ConnectionAdapters::Mysql2Adapter.prepend TypeMapOverride if defined? ActiveRecord::ConnectionAdapters::Mysql2Adapter
           ActiveRecord::ConnectionAdapters::SQLite3Adapter.prepend TypeMapOverride if defined? ActiveRecord::ConnectionAdapters::SQLite3Adapter

--- a/lib/activeuuid/uuid.rb
+++ b/lib/activeuuid/uuid.rb
@@ -103,7 +103,7 @@ module ActiveUUID
       class_attribute :_uuid_generator, instance_writer: false
       self._uuid_generator = :random
 
-      singleton_class.alias_method_chain :instantiate, :uuid
+      singleton_class.prepend Instantiation
       before_create :generate_uuids_if_needed
     end
 
@@ -128,15 +128,18 @@ module ActiveUUID
         EOS
       end
 
-      def instantiate_with_uuid(record, record_models = nil)
+      def uuid_columns
+        @uuid_columns ||= columns.select { |c| c.type == :uuid }.map(&:name)
+      end
+    end
+
+    module Instantiation
+      def instantiate(record, record_models = nil)
         uuid_columns.each do |uuid_column|
           record[uuid_column] = UUIDTools::UUID.serialize(record[uuid_column]).to_s if record[uuid_column]
         end
-        instantiate_without_uuid(record)
-      end
 
-      def uuid_columns
-        @uuid_columns ||= columns.select { |c| c.type == :uuid }.map(&:name)
+        super(record)
       end
     end
 

--- a/spec/lib/activerecord_spec.rb
+++ b/spec/lib/activerecord_spec.rb
@@ -2,11 +2,17 @@ require 'spec_helper'
 
 describe ActiveRecord::Base do
   context '.connection' do
+    def table_exists?(connection, table_name)
+      connection.respond_to?(:data_source_exists?) ?
+        connection.data_source_exists?(table_name) :
+        connection.table_exists?(table_name)
+    end
+
     let!(:connection) { ActiveRecord::Base.connection }
     let(:table_name) { :test_uuid_field_creation }
 
     before do
-      connection.drop_table(table_name) if connection.data_source_exists?(table_name)
+      connection.drop_table(table_name) if table_exists?(connection, table_name)
       connection.create_table(table_name)
     end
 
@@ -14,7 +20,7 @@ describe ActiveRecord::Base do
       connection.drop_table table_name
     end
 
-    specify { connection.data_source_exists?(table_name).should be_truthy }
+    specify { table_exists?(connection, table_name).should be_truthy }
 
     context '#add_column' do
       let(:column_name) { :uuid_column }

--- a/spec/lib/activerecord_spec.rb
+++ b/spec/lib/activerecord_spec.rb
@@ -6,7 +6,7 @@ describe ActiveRecord::Base do
     let(:table_name) { :test_uuid_field_creation }
 
     before do
-      connection.drop_table(table_name) if connection.table_exists?(table_name)
+      connection.drop_table(table_name) if connection.data_source_exists?(table_name)
       connection.create_table(table_name)
     end
 
@@ -14,7 +14,7 @@ describe ActiveRecord::Base do
       connection.drop_table table_name
     end
 
-    specify { connection.table_exists?(table_name).should be_truthy }
+    specify { connection.data_source_exists?(table_name).should be_truthy }
 
     context '#add_column' do
       let(:column_name) { :uuid_column }
@@ -218,4 +218,3 @@ describe UuidArticleWithNamespace do
     its(:id) { should == uuid }
   end
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,10 +8,10 @@ require 'active_support/all'
 
 ActiveRecord::Base.logger = Logger.new(File.dirname(__FILE__) + "/debug.log")
 ActiveRecord::Base.configurations = YAML::load(File.read(File.dirname(__FILE__) + "/support/database.yml"))
-ActiveRecord::Base.establish_connection((ENV["DB"] || "sqlite3").to_sym)
 
 require 'activeuuid'
 
+ActiveRecord::Base.establish_connection((ENV["DB"] || "sqlite3").to_sym)
 ActiveRecord::Migrator.migrate(File.dirname(__FILE__) + "/support/migrate")
 ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, STDOUT)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,19 @@ ActiveRecord::Base.configurations = YAML::load(File.read(File.dirname(__FILE__) 
 require 'activeuuid'
 
 ActiveRecord::Base.establish_connection((ENV["DB"] || "sqlite3").to_sym)
+
+if ENV['DB'] == 'mysql'
+  if ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR <= 1
+    class ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter
+      NATIVE_DATABASE_TYPES[:primary_key] = "int(11) auto_increment PRIMARY KEY"
+    end
+  elsif ActiveRecord::VERSION::MAJOR == 3
+    class ActiveRecord::ConnectionAdapters::Mysql2Adapter
+      NATIVE_DATABASE_TYPES[:primary_key] = "int(11) auto_increment PRIMARY KEY"
+    end
+  end
+end
+
 ActiveRecord::Migrator.migrate(File.dirname(__FILE__) + "/support/migrate")
 ActiveRecord::SchemaDumper.dump(ActiveRecord::Base.connection, STDOUT)
 


### PR DESCRIPTION
# Issues resolved
## Timing mismatch between AR connection adapter loading and monkey-patching

In Rails 5, monkey-patches loaded by `ActiveUUID::Patches.apply!` were not properly injected to connection adapters as original connection adapters are not loaded by the time `apply!` method is invoked.

The connection adapters are loaded when connection spec is analyzed and resolved by [`ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver#spec`](https://github.com/rails/rails/blob/98d33e3789adc098a1b866aee1d637660018270c/activerecord/lib/active_record/connection_adapters/connection_specification.rb#L168), which is invoked inside `ActiveRecord::Base#establish_connection`.

I've added a workaround by performing the patches immediately after connections are established, using `Module#prepend`.
## Invalid serialization of UUID-type columns

Due to refactoring of column type metadata classes (the type class definitions are moved into [ActiveModel](https://github.com/rails/rails/tree/master/activemodel/lib/active_model/type)), a new interface for value serialization is introduced.

I overrided the new `ActiveRecord::Type::UUID#serialize` method to serialize UUID values as desired.
## Deprecated `alias_method_chain`

I replaced `alias_method_chain` with `Module#prepend` where it can be done easily.
