### PR TITLE
Rails5 Update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source "http://rubygems.org"
 
 # Specify your gem's dependencies in activeuuid.gemspec
 gemspec
-
-gem "activerecord"
+gem 'rake', '< 11.0'
+gem "activerecord", "~>5.0"

--- a/lib/activeuuid/patches.rb
+++ b/lib/activeuuid/patches.rb
@@ -1,12 +1,18 @@
 require 'active_record'
 require 'active_support/concern'
 
-if ActiveRecord::VERSION::MAJOR == 4 and ActiveRecord::VERSION::MINOR == 2
+if (ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR == 2) ||
+  (ActiveRecord::VERSION::MAJOR == 5 && ActiveRecord::VERSION::MINOR == 0)
   module ActiveRecord
     module Type
       class UUID < Binary # :nodoc:
         def type
           :uuid
+        end
+
+        def serialize(value)
+          return if value.nil?
+          UUIDTools::UUID.serialize(value)
         end
 
         def cast_value(value)
@@ -24,7 +30,6 @@ if ActiveRecord::VERSION::MAJOR == 4 and ActiveRecord::VERSION::MINOR == 2
             def type_cast_from_user(value)
               UUIDTools::UUID.serialize(value) if value
             end
-            alias_method :type_cast_from_database, :type_cast_from_user
           end
         end
       end
@@ -51,31 +56,24 @@ module ActiveUUID
         def type_cast_with_uuid(value)
           return UUIDTools::UUID.serialize(value) if type == :uuid
           super
-          #type_cast_without_uuid(value)
         end
 
         def type_cast_code_with_uuid(var_name)
           return "UUIDTools::UUID.serialize(#{var_name})" if type == :uuid
           super
-          #type_cast_code_without_uuid(var_name)
         end
 
         def simplified_type_with_uuid(field_type)
           return :uuid if field_type == 'binary(16)' || field_type == 'binary(16,0)'
           super
-          #simplified_type_without_uuid(field_type)
         end
-
-#        alias_method_chain :type_cast, :uuid
-#        alias_method_chain :type_cast_code, :uuid if ActiveRecord::VERSION::MAJOR < 4
-#        alias_method_chain :simplified_type, :uuid
       end
     end
 
     module MysqlJdbcColumn
       extend ActiveSupport::Concern
 
-      def self.prepended(klass)
+      included do
         # This is a really hacky solution, but it's the only way to support the
         # MySql JDBC adapter without breaking backwards compatibility.
         # It would be a lot easier if AR had support for custom defined types.
@@ -88,12 +86,11 @@ module ActiveUUID
         # (5)     Since it's no a uuid (see step 3), simplified_type_without_uuid is called,
         #         which maps to AR::ConnectionAdapters::Column.simplified_type (which has no super call, so we're good)
         #
-        #        alias_method :original_simplified_type, :simplified_type
+        alias_method :original_simplified_type, :simplified_type
 
         def simplified_type(field_type)
           return :uuid if field_type == 'binary(16)' || field_type == 'binary(16,0)'
-          super
-#          original_simplified_type(field_type)
+          original_simplified_type(field_type)
         end
       end
     end
@@ -106,17 +103,13 @@ module ActiveUUID
         def type_cast_with_uuid(value)
           return UUIDTools::UUID.serialize(value) if type == :uuid
           super
-          #type_cast_without_uuid(value)
         end
         alias_method_chain :type_cast, :uuid if ActiveRecord::VERSION::MAJOR >= 4
 
         def simplified_type_with_pguuid(field_type)
           return :uuid if field_type == 'uuid'
           super
-          #simplified_type_without_pguuid(field_type)
         end
-
-        #alias_method_chain :simplified_type, :pguuid
       end
     end
 
@@ -127,22 +120,16 @@ module ActiveUUID
         def quote_with_visiting(value, column = nil)
           value = UUIDTools::UUID.serialize(value) if column && column.type == :uuid
           super
-          #quote_without_visiting(value, column)
         end
 
         def type_cast_with_visiting(value, column = nil)
           value = UUIDTools::UUID.serialize(value) if column && column.type == :uuid
           super
-          #type_cast_without_visiting(value, column)
         end
 
         def native_database_types_with_uuid
           @native_database_types ||= native_database_types_without_uuid.merge(uuid: { name: 'binary', limit: 16 })
         end
-
-        #alias_method_chain :quote, :visiting
-        #alias_method_chain :type_cast, :visiting
-        #alias_method_chain :native_database_types, :uuid
       end
     end
 
@@ -154,57 +141,74 @@ module ActiveUUID
           value = UUIDTools::UUID.serialize(value) if column && column.type == :uuid
           value = value.to_s if value.is_a? UUIDTools::UUID
           super
-          #quote_without_visiting(value, column)
         end
 
         def type_cast_with_visiting(value, column = nil, *args)
           value = UUIDTools::UUID.serialize(value) if column && column.type == :uuid
           value = value.to_s if value.is_a? UUIDTools::UUID
           super
-          #type_cast_without_visiting(value, column, *args)
         end
 
         def native_database_types_with_pguuid
           @native_database_types ||= native_database_types_without_pguuid.merge(uuid: { name: 'uuid' })
         end
-
-        #alias_method_chain :quote, :visiting
-        #alias_method_chain :type_cast, :visiting
-        #alias_method_chain :native_database_types, :pguuid
       end
     end
 
-    module AbstractAdapter
-      extend ActiveSupport::Concern
+    module PostgresqlTypeOverride
+      def deserialize(value)
+        UUIDTools::UUID.serialize(value) if value
+      end
 
-      def self.prepended(klass)
-        def initialize_type_map_with_uuid(m)
-          #initialize_type_map_without_uuid(m)
-          super
-          register_class_with_limit m, /binary\(16(,0)?\)/i, ::ActiveRecord::Type::UUID
+      alias_method :cast, :deserialize
+    end
+
+    module TypeMapOverride
+      def initialize_type_map(m)
+        super
+
+        register_class_with_limit m, /binary\(16(,0)?\)/i, ::ActiveRecord::Type::UUID
+      end
+    end
+
+    module MysqlTypeToSqlOverride
+      def type_to_sql(type, limit = nil, precision = nil, scale = nil, unsigned = nil)
+        type.to_s == 'uuid' ? 'binary(16)' : super
+      end
+    end
+
+    module ConnectionHandling
+      def establish_connection(_ = nil)
+        super
+
+        ActiveRecord::ConnectionAdapters::Table.send :include, Migrations if defined? ActiveRecord::ConnectionAdapters::Table
+        ActiveRecord::ConnectionAdapters::TableDefinition.send :include, Migrations if defined? ActiveRecord::ConnectionAdapters::TableDefinition
+
+        if ActiveRecord::VERSION::MAJOR == 5 && ActiveRecord::VERSION::MINOR == 0
+          if defined? ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter
+            ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter.prepend TypeMapOverride
+            ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter.prepend MysqlTypeToSqlOverride
+          end
+
+          ActiveRecord::ConnectionAdapters::SQLite3Adapter.prepend TypeMapOverride if defined? ActiveRecord::ConnectionAdapters::SQLite3Adapter
+          ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Uuid.prepend PostgresqlTypeOverride if defined? ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
+        elsif ActiveRecord::VERSION::MAJOR == 4 && ActiveRecord::VERSION::MINOR == 2
+          ActiveRecord::ConnectionAdapters::Mysql2Adapter.prepend TypeMapOverride if defined? ActiveRecord::ConnectionAdapters::Mysql2Adapter
+          ActiveRecord::ConnectionAdapters::SQLite3Adapter.prepend TypeMapOverride if defined? ActiveRecord::ConnectionAdapters::SQLite3Adapter
+        else
+          ActiveRecord::ConnectionAdapters::Column.send :include, Column
+          ActiveRecord::ConnectionAdapters::PostgreSQLColumn.send :include, PostgreSQLColumn if defined? ActiveRecord::ConnectionAdapters::PostgreSQLColumn
         end
 
-        #alias_method_chain :initialize_type_map, :uuid
+        ActiveRecord::ConnectionAdapters::MysqlAdapter.send :include, Quoting if defined? ActiveRecord::ConnectionAdapters::MysqlAdapter
+        ActiveRecord::ConnectionAdapters::Mysql2Adapter.send :include, Quoting if defined? ActiveRecord::ConnectionAdapters::Mysql2Adapter
+        ActiveRecord::ConnectionAdapters::SQLite3Adapter.send :include, Quoting if defined? ActiveRecord::ConnectionAdapters::SQLite3Adapter
+        ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.send :include, PostgreSQLQuoting if defined? ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
       end
     end
 
     def self.apply!
-      ActiveRecord::ConnectionAdapters::Table.send :prepend, Migrations if defined? ActiveRecord::ConnectionAdapters::Table
-      ActiveRecord::ConnectionAdapters::TableDefinition.send :prepend, Migrations if defined? ActiveRecord::ConnectionAdapters::TableDefinition
-
-      if ActiveRecord::VERSION::MAJOR == 4 and ActiveRecord::VERSION::MINOR == 2
-        ActiveRecord::ConnectionAdapters::Mysql2Adapter.send :prepend, AbstractAdapter if defined? ActiveRecord::ConnectionAdapters::Mysql2Adapter
-        ActiveRecord::ConnectionAdapters::SQLite3Adapter.send :prepend, AbstractAdapter if defined? ActiveRecord::ConnectionAdapters::SQLite3Adapter
-      else
-        ActiveRecord::ConnectionAdapters::Column.send :prepend, Column
-        ActiveRecord::ConnectionAdapters::PostgreSQLColumn.send :prepend, PostgreSQLColumn if defined? ActiveRecord::ConnectionAdapters::PostgreSQLColumn
-      end
-      ArJdbc::MySQL::Column.send :prepend, MysqlJdbcColumn if defined? ArJdbc::MySQL::Column
-
-      ActiveRecord::ConnectionAdapters::MysqlAdapter.send :prepend, Quoting if defined? ActiveRecord::ConnectionAdapters::MysqlAdapter
-      ActiveRecord::ConnectionAdapters::Mysql2Adapter.send :prepend, Quoting if defined? ActiveRecord::ConnectionAdapters::Mysql2Adapter
-      ActiveRecord::ConnectionAdapters::SQLite3Adapter.send :prepend, Quoting if defined? ActiveRecord::ConnectionAdapters::SQLite3Adapter
-      ActiveRecord::ConnectionAdapters::PostgreSQLAdapter.send :prepend, PostgreSQLQuoting if defined? ActiveRecord::ConnectionAdapters::PostgreSQLAdapter
+      ActiveRecord::Base.singleton_class.prepend ConnectionHandling
     end
   end
 end


### PR DESCRIPTION
Removed the `alias_method_chain`s since that is being deprecated.  Also forced a version of Rake to allow all tests to pass